### PR TITLE
Release version 0.1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject stanford-nlp-tools "0.1.0-SNAPSHOT"
+(defproject stanford-nlp-tools "0.1.0"
   :description "Clojure wrapper around the Stanford NLP tools"
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [edu.stanford.nlp/stanford-corenlp "1.3.3"]])


### PR DESCRIPTION
Removed "-SNAPSHOT" in project.clj in order to deploy stanford-nlp-tools in clojars without -SNAPSHOT
